### PR TITLE
fetch PHP version from PATH instead of hard-coding it

### DIFF
--- a/Files/WebJob/cronWebJob.ps1
+++ b/Files/WebJob/cronWebJob.ps1
@@ -4,6 +4,16 @@
 
 $cronFile = "$($env:HOME)\site\wwwroot\cron.php"
 
-$phpExe = "${env:ProgramFiles(x86)}\PHP\v7.3\php.exe"
-Start-Process -NoNewWindow -FilePath $phpExe -ArgumentList @($cronFile)
+# clear out all variables just in case
+Remove-Variable phpGenericExe,phpExe,phpMatchPath,phpMatchExe -ErrorAction SilentlyContinue
 
+# auto-fetch path to currently installed PHP executabe by parsing the PATH environment variable. 
+# (this works b/c when the PHP version is updated, the App Service correspondingly updates the PATH variable with updated PHP version path)
+$phpGenericExe = "${env:ProgramFiles}\PHP\v7.3\php.exe"
+$phpMatchPath = $($(${Env:PATH} -split ";") -match "\\PHP\\v")
+$phpMatchExe = Join-Path -Path $phpMatchPath -ChildPath "php.exe"
+
+# use path only if it exists, otherwise use generic/hard-coded path
+$phpExe = @($phpMatchExe,$phpGenericExe)[!$(Test-Path -path $phpMatchExe)]
+
+Start-Process -NoNewWindow -FilePath $phpExe -ArgumentList @($cronFile)


### PR DESCRIPTION
This PR updates the Web Job to dynamically use the same version of PHP that is configured in the App Service, instead of having the version number hard-coded.

It does this by parsing the PATH environment variable, which is always updated with the PHP version that is reconfigured in App Service > Configuration blade.

This should ensure that the version of PHP used by the web job remains consistent with the version installed in Azure app service, and should make the process for upgrading PHP in App Service-hosted REDCap installations more consistent and streamlined.

[Otherwise, to ensure consistency in PHP versions, admins would need to do the upgrade in two steps: (1) Change PHP version from App Service's Configuration blade and (2) also update this script and redeploy the Web Job.]